### PR TITLE
Add login page and JWT auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
 PORT=3000
 DATABASE_URL=postgres://postgres:postgres@db:5432/qsdata
+JWT_SECRET=your_jwt_secret

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ docker-compose up --build
 
 The API will be available at `http://localhost:3000`.
 
+The `.env` file requires `JWT_SECRET` which is used to sign login tokens.
+
 ## Running Tests
 
 ```bash

--- a/authUsers.js
+++ b/authUsers.js
@@ -1,0 +1,4 @@
+module.exports = [
+  { username: 'admin', passwordHash: '$2b$10$6E6Xxe.kFVD/HnreWIIhlOMCh2e0LyU74VCUqd1sEWZW1DxKBUUUS' },
+  { username: 'user', passwordHash: '$2b$10$vbbBydwIuoSIg2Fy4b0eXOItydffezjF0R3O8YWr1lIK53.53YFAy' }
+];

--- a/client/index.html
+++ b/client/index.html
@@ -5,15 +5,75 @@
     <title>QSData Frontend</title>
     <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
     <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+    <script crossorigin src="https://unpkg.com/react-router-dom@6/umd/react-router-dom.development.js"></script>
     <script crossorigin src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+    <style>
+      body {
+        margin: 0;
+        font-family: Arial, sans-serif;
+        background-image: url('https://images.unsplash.com/photo-1527980965255-d3b416303d12?auto=format&fit=crop&w=1350&q=80');
+        background-size: cover;
+        background-position: center;
+        color: #333;
+      }
+      .login-container {
+        backdrop-filter: blur(4px);
+        background-color: rgba(255,255,255,0.8);
+        padding: 20px;
+        max-width: 300px;
+        margin: 100px auto;
+        border-radius: 8px;
+        box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+      }
+      label { display: block; margin-bottom: 8px; }
+      input { width: 100%; padding: 8px; margin-bottom: 12px; }
+      button { width: 100%; padding: 8px; }
+      ul { background: rgba(255,255,255,0.9); padding: 20px; list-style: none; }
+    </style>
   </head>
   <body>
     <div id="root"></div>
     <script type="text/babel">
-      function App() {
+      const { BrowserRouter, Routes, Route, useNavigate } = ReactRouterDOM;
+
+      function Login() {
+        const [username, setUsername] = React.useState('');
+        const [password, setPassword] = React.useState('');
+        const navigate = useNavigate();
+        const submit = async e => {
+          e.preventDefault();
+          const res = await fetch('/api/login', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ username, password })
+          });
+          if (res.ok) {
+            const data = await res.json();
+            localStorage.setItem('token', data.token);
+            navigate('/');
+          } else {
+            alert('Invalid credentials');
+          }
+        };
+        return (
+          <div className="login-container">
+            <h2>Login</h2>
+            <form onSubmit={submit}>
+              <label>Username</label>
+              <input value={username} onChange={e => setUsername(e.target.value)} />
+              <label>Password</label>
+              <input type="password" value={password} onChange={e => setPassword(e.target.value)} />
+              <button type="submit">Login</button>
+            </form>
+          </div>
+        );
+      }
+
+      function Home() {
         const [items, setItems] = React.useState([]);
         React.useEffect(() => {
-          fetch('/api/progress')
+          const token = localStorage.getItem('token');
+          fetch('/api/progress', { headers: { Authorization: `Bearer ${token}` } })
             .then(res => res.json())
             .then(setItems);
         }, []);
@@ -25,6 +85,18 @@
           </ul>
         );
       }
+
+      function App() {
+        return (
+          <BrowserRouter>
+            <Routes>
+              <Route path="/login" element={<Login />} />
+              <Route path="/*" element={<Home />} />
+            </Routes>
+          </BrowserRouter>
+        );
+      }
+
       ReactDOM.createRoot(document.getElementById('root')).render(<App />);
     </script>
   </body>

--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -1,0 +1,17 @@
+const jwt = require('jsonwebtoken');
+const bcrypt = require('bcryptjs');
+const users = require('../authUsers');
+
+exports.login = async (req, res) => {
+  const { username, password } = req.body;
+  const user = users.find(u => u.username === username);
+  if (!user) {
+    return res.status(401).json({ error: 'Invalid credentials' });
+  }
+  const match = await bcrypt.compare(password, user.passwordHash);
+  if (!match) {
+    return res.status(401).json({ error: 'Invalid credentials' });
+  }
+  const token = jwt.sign({ username }, process.env.JWT_SECRET || 'secret', { expiresIn: '1h' });
+  res.json({ token });
+};

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -3,3 +3,9 @@ CREATE TABLE IF NOT EXISTS progress (
   description TEXT NOT NULL,
   completed BOOLEAN DEFAULT false
 );
+
+CREATE TABLE IF NOT EXISTS users (
+  id SERIAL PRIMARY KEY,
+  username TEXT UNIQUE NOT NULL,
+  password_hash TEXT NOT NULL
+);

--- a/db/seed.sql
+++ b/db/seed.sql
@@ -1,3 +1,6 @@
 INSERT INTO progress (description, completed) VALUES
 ('Initial setup', true),
 ('Implement API', false);
+
+INSERT INTO users (username, password_hash) VALUES
+('admin', '$2b$10$6E6Xxe.kFVD/HnreWIIhlOMCh2e0LyU74VCUqd1sEWZW1DxKBUUUS');

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ const express = require('express');
 const path = require('path');
 const dotenv = require('dotenv');
 const progressRouter = require('./routes/progress');
+const authRouter = require('./routes/auth');
 
 dotenv.config();
 
@@ -10,6 +11,7 @@ const PORT = process.env.PORT || 3000;
 
 app.use(express.json());
 
+app.use('/api', authRouter);
 app.use('/api/progress', progressRouter);
 app.use(express.static(path.join(__dirname, 'client')));
 

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -1,0 +1,16 @@
+const jwt = require('jsonwebtoken');
+
+module.exports = function(req, res, next) {
+  const auth = req.headers.authorization;
+  if (!auth || !auth.startsWith('Bearer ')) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+  const token = auth.split(' ')[1];
+  try {
+    const decoded = jwt.verify(token, process.env.JWT_SECRET || 'secret');
+    req.user = decoded;
+    next();
+  } catch (err) {
+    res.status(401).json({ error: 'Invalid token' });
+  }
+};

--- a/package.json
+++ b/package.json
@@ -13,14 +13,17 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "bcryptjs": "^3.0.2",
+    "dotenv": "^16.3.1",
     "express": "^4.18.2",
-    "pg": "^8.11.1",
-    "dotenv": "^16.3.1"
+    "express-session": "^1.18.2",
+    "jsonwebtoken": "^9.0.2",
+    "pg": "^8.11.1"
   },
   "devDependencies": {
-    "jest": "^29.7.0",
     "eslint": "^8.56.0",
-    "supertest": "^6.3.3",
-    "nodemon": "^3.0.1"
+    "jest": "^29.7.0",
+    "nodemon": "^3.0.1",
+    "supertest": "^6.3.3"
   }
 }

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -1,0 +1,7 @@
+const express = require('express');
+const router = express.Router();
+const controller = require('../controllers/authController');
+
+router.post('/login', controller.login);
+
+module.exports = router;

--- a/routes/progress.js
+++ b/routes/progress.js
@@ -1,8 +1,9 @@
 const express = require('express');
 const router = express.Router();
 const controller = require('../controllers/progressController');
+const auth = require('../middleware/auth');
 
-router.get('/', controller.getAll);
-router.post('/', controller.create);
+router.get('/', auth, controller.getAll);
+router.post('/', auth, controller.create);
 
 module.exports = router;

--- a/tests/progress.test.js
+++ b/tests/progress.test.js
@@ -1,6 +1,7 @@
 const request = require('supertest');
 const express = require('express');
 const progressRouter = require('../routes/progress');
+const jwt = require('jsonwebtoken');
 
 jest.mock('../db', () => {
   return {
@@ -14,7 +15,10 @@ app.use('/api/progress', progressRouter);
 
 describe('GET /api/progress', () => {
   it('responds with array', async () => {
-    const res = await request(app).get('/api/progress');
+    const token = jwt.sign({ username: 'test' }, 'secret');
+    const res = await request(app)
+      .get('/api/progress')
+      .set('Authorization', `Bearer ${token}`);
     expect(Array.isArray(res.body)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- implement login endpoint using JWT and bcrypt
- secure progress API with auth middleware
- create users table and seed admin
- style React client with login page and route to home
- document new environment variable for JWT secret

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68841d98b76c83279a18c5089d8060d7