### PR TITLE
Use env JWT_SECRET in tests

### DIFF
--- a/tests/progress.test.js
+++ b/tests/progress.test.js
@@ -15,7 +15,10 @@ app.use('/api/progress', progressRouter);
 
 describe('GET /api/progress', () => {
   it('responds with array', async () => {
-    const token = jwt.sign({ username: 'test' }, 'secret');
+    const token = jwt.sign(
+      { username: 'test' },
+      process.env.JWT_SECRET || 'secret',
+    );
     const res = await request(app)
       .get('/api/progress')
       .set('Authorization', `Bearer ${token}`);


### PR DESCRIPTION
## Summary
- read `process.env.JWT_SECRET` in tests for signing tokens

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688421f0292c832794c18d1d97e39fb2