### PR TITLE
Add master user Saad, roles and new layout

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+client/vendor/*

--- a/authUsers.js
+++ b/authUsers.js
@@ -1,4 +1,5 @@
 module.exports = [
-  { username: 'admin', passwordHash: '$2b$10$6E6Xxe.kFVD/HnreWIIhlOMCh2e0LyU74VCUqd1sEWZW1DxKBUUUS' },
-  { username: 'user', passwordHash: '$2b$10$vbbBydwIuoSIg2Fy4b0eXOItydffezjF0R3O8YWr1lIK53.53YFAy' }
+  { username: 'admin', passwordHash: '$2b$10$6E6Xxe.kFVD/HnreWIIhlOMCh2e0LyU74VCUqd1sEWZW1DxKBUUUS', role: 'admin' },
+  { username: 'user', passwordHash: '$2b$10$vbbBydwIuoSIg2Fy4b0eXOItydffezjF0R3O8YWr1lIK53.53YFAy', role: 'user' },
+  { username: 'Saad', passwordHash: '$2b$10$poBZntjhvCCuxPbTSv0xLO4xDgPh6hiMs4C2NOvFjrnmALLlBJlDi', role: 'DG' }
 ];

--- a/client/index.html
+++ b/client/index.html
@@ -59,6 +59,31 @@
         padding: 20px;
         list-style: none;
       }
+      .layout {
+        display: grid;
+        grid-template-columns: 200px 1fr;
+        grid-template-rows: 60px 1fr;
+        min-height: 100vh;
+      }
+      header {
+        grid-column: 1 / span 2;
+        display: flex;
+        align-items: center;
+        padding: 0 20px;
+        background: #343a40;
+        color: #fff;
+      }
+      header a {
+        color: #fff;
+        text-decoration: none;
+      }
+      aside {
+        background: #f8f9fa;
+        padding: 20px;
+      }
+      main {
+        padding: 20px;
+      }
     </style>
   </head>
   <body>
@@ -80,6 +105,9 @@
           if (res.ok) {
             const data = await res.json();
             localStorage.setItem('token', data.token);
+            if (data.role) {
+              localStorage.setItem('role', data.role);
+            }
             navigate('/home');
           } else {
             alert('Invalid credentials');
@@ -108,11 +136,25 @@
             .then(setItems);
         }, []);
         return (
-          <ul>
-            {items.map(i => (
-              <li key={i.id}>{i.description} - {i.completed ? 'done' : 'pending'}</li>
-            ))}
-          </ul>
+          <div className="layout">
+            <header>
+              <h1><a href="/home">QSData</a></h1>
+            </header>
+            <aside>
+              <nav>
+                <ul>
+                  <li><a href="/home">Home</a></li>
+                </ul>
+              </nav>
+            </aside>
+            <main>
+              <ul>
+                {items.map(i => (
+                  <li key={i.id}>{i.description} - {i.completed ? 'done' : 'pending'}</li>
+                ))}
+              </ul>
+            </main>
+          </div>
         );
       }
 

--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -12,6 +12,6 @@ exports.login = async (req, res) => {
   if (!match) {
     return res.status(401).json({ error: 'Invalid credentials' });
   }
-  const token = jwt.sign({ username }, process.env.JWT_SECRET || 'secret', { expiresIn: '1h' });
-  res.json({ token });
+  const token = jwt.sign({ username, role: user.role }, process.env.JWT_SECRET || 'secret', { expiresIn: '1h' });
+  res.json({ token, role: user.role });
 };

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -7,5 +7,6 @@ CREATE TABLE IF NOT EXISTS progress (
 CREATE TABLE IF NOT EXISTS users (
   id SERIAL PRIMARY KEY,
   username TEXT UNIQUE NOT NULL,
-  password_hash TEXT NOT NULL
+  password_hash TEXT NOT NULL,
+  role TEXT NOT NULL
 );

--- a/db/seed.sql
+++ b/db/seed.sql
@@ -2,5 +2,6 @@ INSERT INTO progress (description, completed) VALUES
 ('Initial setup', true),
 ('Implement API', false);
 
-INSERT INTO users (username, password_hash) VALUES
-('admin', '$2b$10$6E6Xxe.kFVD/HnreWIIhlOMCh2e0LyU74VCUqd1sEWZW1DxKBUUUS');
+INSERT INTO users (username, password_hash, role) VALUES
+('admin', '$2b$10$6E6Xxe.kFVD/HnreWIIhlOMCh2e0LyU74VCUqd1sEWZW1DxKBUUUS', 'admin'),
+('Saad', '$2b$10$poBZntjhvCCuxPbTSv0xLO4xDgPh6hiMs4C2NOvFjrnmALLlBJlDi', 'DG');


### PR DESCRIPTION
## Summary
- add a `role` column to `users` table
- seed master user Saad with DG role
- include roles in hard-coded auth user list
- return role info from login endpoint
- add sidebar and header layout to client
- ignore vendor files in ESLint

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6884304cd4f8832790e01cf77c1df37b