### PR TITLE
Add project schemas and role-based routes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 PORT=3000
 DATABASE_URL=postgres://postgres:postgres@db:5432/qsdata
 JWT_SECRET=your_jwt_secret
+CLIENT_ORIGIN=http://localhost:3000

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # QSData
 
-QSData is a sample PERN stack application (PostgreSQL, Express, React, Node). It provides a basic API for tracking project progress and a React-based front end.
+QSData is a PERN stack application for managing Pakistan PWD project data.
+It implements JWT authentication, role based access control and several project tables.
 
 ## Features
 
@@ -26,13 +27,20 @@ QSData is a sample PERN stack application (PostgreSQL, Express, React, Node). It
 npm install
 ```
 
-3. Start the database and server using Docker Compose:
+3. Initialize the database schema and seed data:
+
+```bash
+npm run db:init
+```
+
+4. Start the database and server using Docker Compose:
 
 ```bash
 docker-compose up --build
 ```
 
 The API will be available at `http://localhost:3000`.
+`CLIENT_ORIGIN` controls which origin can access the API via CORS.
 
 The `.env` file requires `JWT_SECRET` which is used to sign login tokens.
 

--- a/authUsers.js
+++ b/authUsers.js
@@ -1,5 +1,6 @@
 module.exports = [
-  { username: 'admin', passwordHash: '$2b$10$6E6Xxe.kFVD/HnreWIIhlOMCh2e0LyU74VCUqd1sEWZW1DxKBUUUS', role: 'admin' },
-  { username: 'user', passwordHash: '$2b$10$vbbBydwIuoSIg2Fy4b0eXOItydffezjF0R3O8YWr1lIK53.53YFAy', role: 'user' },
-  { username: 'Saad', passwordHash: '$2b$10$poBZntjhvCCuxPbTSv0xLO4xDgPh6hiMs4C2NOvFjrnmALLlBJlDi', role: 'DG' }
+  { username: 'Saad', passwordHash: '$2b$10$HBEP2mujXFgGlvRhEd2Mie9Gh90t3OqYgYsZa1v8my7rlm4Z8xn.e', role: 'master' },
+  { username: 'originator1', passwordHash: '$2b$10$J5HEZLpU9d/kKYetwyO2t.Ce1G2AzixpHOJnxIzHDGshKbiAuv0sO', role: 'originator' },
+  { username: 'originator2', passwordHash: '$2b$10$J5HEZLpU9d/kKYetwyO2t.Ce1G2AzixpHOJnxIzHDGshKbiAuv0sO', role: 'originator' },
+  { username: 'senior1', passwordHash: '$2b$10$J5HEZLpU9d/kKYetwyO2t.Ce1G2AzixpHOJnxIzHDGshKbiAuv0sO', role: 'senior' }
 ];

--- a/controllers/psdpController.js
+++ b/controllers/psdpController.js
@@ -1,0 +1,11 @@
+const pool = require('../db');
+
+exports.getAll = async (req, res) => {
+  try {
+    const { rows } = await pool.query('SELECT * FROM psdp_projects ORDER BY id');
+    res.json(rows);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Database error' });
+  }
+};

--- a/controllers/sapController.js
+++ b/controllers/sapController.js
@@ -1,0 +1,57 @@
+const pool = require('../db');
+
+exports.getAll = async (req, res) => {
+  try {
+    const { rows } = await pool.query('SELECT * FROM sap_projects ORDER BY sr_no');
+    res.json(rows);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Database error' });
+  }
+};
+
+exports.create = async (req, res) => {
+  const {
+    sr_no,
+    s_no,
+    name_of_scheme,
+    originator,
+  } = req.body;
+  try {
+    const { rows } = await pool.query(
+      `INSERT INTO sap_projects (sr_no, s_no, name_of_scheme, originator) VALUES ($1,$2,$3,$4) RETURNING *`,
+      [sr_no, s_no, name_of_scheme, originator]
+    );
+    res.status(201).json(rows[0]);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Database error' });
+  }
+};
+
+exports.update = async (req, res) => {
+  const { sr_no } = req.params;
+  const { name_of_scheme } = req.body;
+  try {
+    const { rows } = await pool.query(
+      `UPDATE sap_projects SET name_of_scheme=$1, updated_at=CURRENT_TIMESTAMP WHERE sr_no=$2 RETURNING *`,
+      [name_of_scheme, sr_no]
+    );
+    if (!rows.length) return res.status(404).json({ error: 'Not found' });
+    res.json(rows[0]);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Database error' });
+  }
+};
+
+exports.remove = async (req, res) => {
+  const { sr_no } = req.params;
+  try {
+    await pool.query('DELETE FROM sap_projects WHERE sr_no=$1', [sr_no]);
+    res.sendStatus(204);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Database error' });
+  }
+};

--- a/controllers/zoneController.js
+++ b/controllers/zoneController.js
@@ -1,0 +1,11 @@
+const pool = require('../db');
+
+exports.getAll = async (req, res) => {
+  try {
+    const { rows } = await pool.query('SELECT * FROM zone_summary ORDER BY id');
+    res.json(rows);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Database error' });
+  }
+};

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -10,3 +10,51 @@ CREATE TABLE IF NOT EXISTS users (
   password_hash TEXT NOT NULL,
   role TEXT NOT NULL
 );
+
+CREATE TABLE IF NOT EXISTS sap_projects (
+  sr_no INTEGER PRIMARY KEY,
+  s_no INTEGER,
+  name_of_scheme TEXT,
+  no_of_schemes INTEGER,
+  executing_agency_name TEXT,
+  sector TEXT,
+  approved_cost DECIMAL(14,2),
+  release DECIMAL(14,2),
+  expenditure DECIMAL(14,2),
+  start_date DATE,
+  completion_date DATE,
+  not_started INTEGER,
+  started INTEGER,
+  status TEXT,
+  year TEXT,
+  district TEXT,
+  division TEXT,
+  province TEXT,
+  category TEXT,
+  pwd_zone TEXT,
+  pwd_division TEXT,
+  schemes_in_one_admin_approval TEXT,
+  originator TEXT,
+  approver TEXT,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS zone_summary (
+  id SERIAL PRIMARY KEY,
+  zone TEXT,
+  no_of_projects INTEGER,
+  approved_cost DECIMAL(14,2),
+  no_handed_over INTEGER,
+  no_remaining INTEGER
+);
+
+CREATE TABLE IF NOT EXISTS psdp_projects (
+  id SERIAL PRIMARY KEY,
+  classification TEXT,
+  psdp_no INTEGER,
+  project_name TEXT,
+  no_of_projects INTEGER,
+  approved_cost DECIMAL(14,2),
+  allocation_2024_25 DECIMAL(14,2)
+);

--- a/db/seed.sql
+++ b/db/seed.sql
@@ -3,5 +3,16 @@ INSERT INTO progress (description, completed) VALUES
 ('Implement API', false);
 
 INSERT INTO users (username, password_hash, role) VALUES
-('admin', '$2b$10$6E6Xxe.kFVD/HnreWIIhlOMCh2e0LyU74VCUqd1sEWZW1DxKBUUUS', 'admin'),
-('Saad', '$2b$10$poBZntjhvCCuxPbTSv0xLO4xDgPh6hiMs4C2NOvFjrnmALLlBJlDi', 'DG');
+('Saad', '$2b$10$HBEP2mujXFgGlvRhEd2Mie9Gh90t3OqYgYsZa1v8my7rlm4Z8xn.e', 'master'),
+('originator1', '$2b$10$J5HEZLpU9d/kKYetwyO2t.Ce1G2AzixpHOJnxIzHDGshKbiAuv0sO', 'originator'),
+('originator2', '$2b$10$J5HEZLpU9d/kKYetwyO2t.Ce1G2AzixpHOJnxIzHDGshKbiAuv0sO', 'originator'),
+('senior1', '$2b$10$J5HEZLpU9d/kKYetwyO2t.Ce1G2AzixpHOJnxIzHDGshKbiAuv0sO', 'senior');
+
+INSERT INTO sap_projects (sr_no, s_no, name_of_scheme) VALUES
+  (1, 101, 'Sample Scheme');
+
+INSERT INTO zone_summary (zone, no_of_projects, approved_cost, no_handed_over, no_remaining) VALUES
+  ('North', 1, 1000000.00, 0, 1);
+
+INSERT INTO psdp_projects (classification, psdp_no, project_name, no_of_projects, approved_cost, allocation_2024_25) VALUES
+  ('A', 1, 'PSDP Project', 1, 500000.00, 100000.00);

--- a/index.js
+++ b/index.js
@@ -1,8 +1,14 @@
 const express = require('express');
 const path = require('path');
 const dotenv = require('dotenv');
+const helmet = require('helmet');
+const cors = require('cors');
+const rateLimit = require('express-rate-limit');
 const progressRouter = require('./routes/progress');
 const authRouter = require('./routes/auth');
+const sapRouter = require('./routes/sapProjects');
+const zoneRouter = require('./routes/zoneSummary');
+const psdpRouter = require('./routes/psdpProjects');
 
 dotenv.config();
 
@@ -10,9 +16,21 @@ const app = express();
 const PORT = process.env.PORT || 3000;
 
 app.use(express.json());
+app.use(helmet());
+app.use(
+  cors({
+    origin: process.env.CLIENT_ORIGIN || '*',
+  })
+);
+app.use(
+  rateLimit({ windowMs: 60 * 1000, max: 100 })
+);
 
 app.use('/api', authRouter);
 app.use('/api/progress', progressRouter);
+app.use('/api/sap-projects', sapRouter);
+app.use('/api/zone-summary', zoneRouter);
+app.use('/api/psdp-projects', psdpRouter);
 app.use(express.static(path.join(__dirname, 'client')));
 
 app.get('*', (req, res) => {

--- a/middleware/role.js
+++ b/middleware/role.js
@@ -1,0 +1,8 @@
+module.exports = function(requiredRoles) {
+  return (req, res, next) => {
+    if (!req.user || !requiredRoles.includes(req.user.role)) {
+      return res.status(403).json({ error: 'Forbidden' });
+    }
+    next();
+  };
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,12 @@
       "license": "ISC",
       "dependencies": {
         "bcryptjs": "^3.0.2",
+        "cors": "^2.8.5",
         "dotenv": "^16.3.1",
         "express": "^4.18.2",
+        "express-rate-limit": "^8.0.1",
+        "express-validator": "^7.2.1",
+        "helmet": "^8.1.0",
         "jsonwebtoken": "^9.0.2",
         "pg": "^8.11.1"
       },
@@ -2005,6 +2009,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/create-jest": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
@@ -2597,6 +2614,37 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.0.1.tgz",
+      "integrity": "sha512-aZVCnybn7TVmxO4BtlmnvX+nuz8qHW124KKJ8dumsBsmv5ZLxE0pYu7S2nwyRBGHHCAzdmnGyrc5U/rksSPO7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.0.1"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/express-validator": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-7.2.1.tgz",
+      "integrity": "sha512-CjNE6aakfpuwGaHQZ3m8ltCG2Qvivd7RHtVMS/6nVxOM7xVGqr4bhflsm4+N5FP5zI7Zxp+Hae+9RE+o8e3ZOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "validator": "~13.12.0"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
     "node_modules/express/node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -3047,6 +3095,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/helmet": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.1.0.tgz",
+      "integrity": "sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -3173,6 +3230,15 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
+      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -4178,6 +4244,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
+    },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -4511,6 +4583,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/object-inspect": {
@@ -5919,6 +6000,15 @@
       },
       "engines": {
         "node": ">=10.12.0"
+      }
+    },
+    "node_modules/validator": {
+      "version": "13.12.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.12.0.tgz",
+      "integrity": "sha512-c1Q0mCiPlgdTVVVIJIrBuxNicYE+t/7oKeI9MWLj3fh/uq2Pxh/3eeWbVZ4OcGW1TUf53At0njHw5SMdA3tmMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/vary": {

--- a/package.json
+++ b/package.json
@@ -14,8 +14,12 @@
   "license": "ISC",
   "dependencies": {
     "bcryptjs": "^3.0.2",
+    "cors": "^2.8.5",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
+    "express-rate-limit": "^8.0.1",
+    "express-validator": "^7.2.1",
+    "helmet": "^8.1.0",
     "jsonwebtoken": "^9.0.2",
     "pg": "^8.11.1"
   },

--- a/routes/progress.js
+++ b/routes/progress.js
@@ -2,8 +2,9 @@ const express = require('express');
 const router = express.Router();
 const controller = require('../controllers/progressController');
 const auth = require('../middleware/auth');
+const role = require('../middleware/role');
 
 router.get('/', auth, controller.getAll);
-router.post('/', auth, controller.create);
+router.post('/', auth, role(['master', 'originator']), controller.create);
 
 module.exports = router;

--- a/routes/psdpProjects.js
+++ b/routes/psdpProjects.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const router = express.Router();
+const controller = require('../controllers/psdpController');
+const auth = require('../middleware/auth');
+
+router.get('/', auth, controller.getAll);
+
+module.exports = router;

--- a/routes/sapProjects.js
+++ b/routes/sapProjects.js
@@ -1,0 +1,19 @@
+const express = require('express');
+const { body } = require('express-validator');
+const router = express.Router();
+const controller = require('../controllers/sapController');
+const auth = require('../middleware/auth');
+const role = require('../middleware/role');
+
+router.get('/', auth, controller.getAll);
+router.post(
+  '/',
+  auth,
+  role(['originator', 'master']),
+  body('sr_no').isInt(),
+  controller.create
+);
+router.put('/:sr_no', auth, role(['master']), controller.update);
+router.delete('/:sr_no', auth, role(['master']), controller.remove);
+
+module.exports = router;

--- a/routes/zoneSummary.js
+++ b/routes/zoneSummary.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const router = express.Router();
+const controller = require('../controllers/zoneController');
+const auth = require('../middleware/auth');
+
+router.get('/', auth, controller.getAll);
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- implement tables for SAP projects, PSDP projects and zone summaries
- seed database with demo users and sample data
- secure API with CORS, helmet, rate limiting and new role middleware
- add CRUD endpoints for SAP projects and summary routes
- document setup steps and environment variables

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68843f0dfdd88327959e0500baa85ace