### PR TITLE
Fix login page by relaxing Helmet security headers

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,20 @@ const app = express();
 const PORT = process.env.PORT || 3000;
 
 app.use(express.json());
-app.use(helmet());
+app.use(
+  helmet({
+    crossOriginOpenerPolicy: false,
+    originAgentCluster: false,
+    contentSecurityPolicy: {
+      directives: {
+        defaultSrc: ["'self'"],
+        scriptSrc: ["'self'", "'unsafe-inline'"],
+        styleSrc: ["'self'", 'https:', "'unsafe-inline'"],
+        imgSrc: ["'self'", 'data:'],
+      },
+    },
+  })
+);
 app.use(
   cors({
     origin: process.env.CLIENT_ORIGIN || '*',


### PR DESCRIPTION
## Summary
- adjust Helmet config to disable COOP/OAC headers
- allow inline scripts in CSP so the React login page can load

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6884405e957883279770cc08ebff461a