### PR TITLE
Add Docker hot-reload setup

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,7 +6,7 @@
   },
   "extends": "eslint:recommended",
   "parserOptions": {
-    "ecmaVersion": 12,
+    "ecmaVersion": 2022,
     "sourceType": "module"
   },
   "rules": {}

--- a/README.md
+++ b/README.md
@@ -48,6 +48,18 @@ docker-compose up --build
 The API will be available at `http://localhost:3000`.
 `CLIENT_ORIGIN` controls which origin can access the API via CORS.
 
+### Development with Docker and hot reloading
+
+When developing locally you can start the stack with `docker-compose.dev.yml`
+to enable hot reloading:
+
+```bash
+docker-compose -f docker-compose.yml -f docker-compose.dev.yml up
+```
+
+The API will still be reachable at `http://localhost:3000` and the React
+dev server will run on `http://localhost:5173`.
+
 The `.env` file requires `JWT_SECRET` which is used to sign login tokens.
 
 ## Running Tests

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,40 @@
+version: '3'
+services:
+  db:
+    image: postgres:14
+    restart: always
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: qsdata
+    volumes:
+      - db-data:/var/lib/postgresql/data
+    ports:
+      - '5432:5432'
+  server:
+    image: node:18
+    working_dir: /app
+    command: sh -c "npm install && npm run dev"
+    volumes:
+      - .:/app
+    ports:
+      - '3000:3000'
+    environment:
+      - DATABASE_URL=postgres://postgres:postgres@db:5432/qsdata
+      - CHOKIDAR_USEPOLLING=1
+    depends_on:
+      - db
+  client:
+    image: node:18
+    working_dir: /app
+    command: sh -c "npm install && npm run client"
+    volumes:
+      - .:/app
+    ports:
+      - '5173:5173'
+    environment:
+      - CHOKIDAR_USEPOLLING=1
+    depends_on:
+      - server
+volumes:
+  db-data:


### PR DESCRIPTION
## Summary
- add a `docker-compose.dev.yml` file with server and client services using nodemon and Vite
- document how to run the dev stack with hot reloading
- update ESLint config to support top-level await

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6886e18ce44083279222ad73f6a7394e