### PR TITLE
Add nodemon config to rebuild client

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ dev server will run on `http://localhost:5173`.
 
 The `.env` file requires `JWT_SECRET` which is used to sign login tokens.
 
+### Local development with nodemon
+
+Run `npm run dev` to start the server with nodemon. The `nodemon.json` config watches `client/src` and rebuilds the client with `npm run client:build` whenever the server restarts. The built files are served from `client/dist` on `http://localhost:3000`.
+
 ## Running Tests
 
 ```bash

--- a/nodemon.json
+++ b/nodemon.json
@@ -1,0 +1,8 @@
+{
+  "watch": ["index.js", "routes", "controllers", "middleware", "client/src"],
+  "ignore": ["client/dist"],
+  "ext": "js,json,jsx",
+  "events": {
+    "restart": "npm run client:build"
+  }
+}


### PR DESCRIPTION
## Summary
- build the client whenever nodemon restarts
- document local development setup with nodemon

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6886f2ee431c8327aafe88b7cf3dca04